### PR TITLE
Change hook order

### DIFF
--- a/core/src/main/java/io/shiftleft/bctrace/asm/Transformer.java
+++ b/core/src/main/java/io/shiftleft/bctrace/asm/Transformer.java
@@ -320,10 +320,10 @@ public class Transformer implements ClassFileTransformer {
       }
     }
     if (hasGenericHooks) {
-      if (startHelper.addByteCodeInstructions(cn, mn, hooksToUse)) {
+      if (mutableStartHelper.addByteCodeInstructions(cn, mn, hooksToUse)) {
         transformed = true;
       }
-      if (mutableStartHelper.addByteCodeInstructions(cn, mn, hooksToUse)) {
+      if (startHelper.addByteCodeInstructions(cn, mn, hooksToUse)) {
         transformed = true;
       }
       if (finishHelper.addByteCodeInstructions(cn, mn, hooksToUse)) {


### PR DESCRIPTION
Changes listener order notification to better suit sl-microagent needs.
This order still is arbitrary (between start hooks of different type), so this hack is not too disturbing.

Created https://github.com/ShiftLeftSecurity/bctrace/issues/41 for properly addressing the ordering

