### PR TITLE
fixes product/issues/2428

### DIFF
--- a/core/src/main/java/io/shiftleft/bctrace/asm/helper/direct/callsite/CallSiteHelper.java
+++ b/core/src/main/java/io/shiftleft/bctrace/asm/helper/direct/callsite/CallSiteHelper.java
@@ -387,9 +387,9 @@ public class CallSiteHelper extends Helper {
         if (filter.acceptCallSite(cn, mn, callSite, lineNumber)) {
           if (il == null) {
             il = new InsnList();
-            Object[] parametersFrameTypes = ASMUtils.getParametersFrameTypes(cn, mn);
+            Object[] topLocals = ASMUtils.getTopLocals(cn, mn);
             il.add(
-                new FrameNode(Opcodes.F_FULL, parametersFrameTypes.length, parametersFrameTypes, 1,
+                new FrameNode(Opcodes.F_FULL, topLocals.length, topLocals, 1,
                     new Object[]{"java/lang/Throwable"}));
             handlerNode = new LabelNode();
             il.insert(handlerNode);

--- a/core/src/main/java/io/shiftleft/bctrace/asm/helper/direct/method/DirectMethodThrowableHelper.java
+++ b/core/src/main/java/io/shiftleft/bctrace/asm/helper/direct/method/DirectMethodThrowableHelper.java
@@ -73,8 +73,8 @@ public class DirectMethodThrowableHelper extends Helper {
     mn.instructions.add(endNode);
 
     InsnList il = new InsnList();
-    Object[] parametersFrameTypes = ASMUtils.getParametersFrameTypes(cn, mn);
-    il.add(new FrameNode(Opcodes.F_FULL, parametersFrameTypes.length, parametersFrameTypes, 1,
+    Object[] topLocals = ASMUtils.getTopLocals(cn, mn);
+    il.add(new FrameNode(Opcodes.F_FULL, topLocals.length, topLocals, 1,
         new Object[]{"java/lang/Throwable"}));
 
     LabelNode handlerNode = new LabelNode();

--- a/core/src/main/java/io/shiftleft/bctrace/asm/helper/generic/method/GenericMethodThrowableHelper.java
+++ b/core/src/main/java/io/shiftleft/bctrace/asm/helper/generic/method/GenericMethodThrowableHelper.java
@@ -111,8 +111,8 @@ public class GenericMethodThrowableHelper extends Helper {
     mn.instructions.add(endNode);
 
     InsnList il = new InsnList();
-    Object[] parametersFrameTypes = ASMUtils.getParametersFrameTypes(cn, mn);
-    il.add(new FrameNode(Opcodes.F_FULL, parametersFrameTypes.length, parametersFrameTypes, 1,
+    Object[] topLocals = ASMUtils.getTopLocals(cn, mn);
+    il.add(new FrameNode(Opcodes.F_FULL, topLocals.length, topLocals, 1,
         new Object[]{"java/lang/Throwable"}));
 
     LabelNode handlerNode = new LabelNode();


### PR DESCRIPTION
https://github.com/ShiftLeftSecurity/product/issues/2428

New Relic agent creates weird (but apparently valid) stack map frames in the bytecode, with local variables entry empty (even though there are local variables accessible), given that they are not used inside the frame.

Then when our agent wraps this frame with one of our own, with the real top set of local variables, the verification fails given that the inner frame local variables do not match.

This patch corrects these rare frames found, with the complete set of local variables