### PR TITLE
refactor and add registry class name setting support

### DIFF
--- a/core/src/main/java/io/shiftleft/bctrace/asm/primitive/InstrumentationPrimitive.java
+++ b/core/src/main/java/io/shiftleft/bctrace/asm/primitive/InstrumentationPrimitive.java
@@ -22,16 +22,16 @@
  * CONVEY OR IMPLY ANY RIGHTS TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS
  * CONTENTS, OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT MAY DESCRIBE, IN WHOLE OR IN PART.
  */
-package io.shiftleft.bctrace.asm.helper;
+package io.shiftleft.bctrace.asm.primitive;
 
 import io.shiftleft.bctrace.Bctrace;
 import io.shiftleft.bctrace.asm.util.ASMUtils;
 import io.shiftleft.bctrace.hook.Hook;
-import io.shiftleft.bctrace.runtime.listener.direct.DirectListener;
 import java.util.ArrayList;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.InsnList;
 import org.objectweb.asm.tree.InsnNode;
 import org.objectweb.asm.tree.JumpInsnNode;
@@ -47,9 +47,12 @@ import org.objectweb.asm.tree.VarInsnNode;
 /**
  * @author Ignacio del Valle Alles idelvall@shiftleft.io
  */
-public abstract class Helper {
+public abstract class InstrumentationPrimitive {
 
   protected Bctrace bctrace;
+
+  public abstract boolean addByteCodeInstructions(String classResgistryName, ClassNode cn, MethodNode mn,
+      ArrayList<Integer> hooksToUse);
 
   public void setBctrace(Bctrace bctrace) {
     this.bctrace = bctrace;

--- a/core/src/main/java/io/shiftleft/bctrace/asm/primitive/direct/callsite/CallSitePrimitive.java
+++ b/core/src/main/java/io/shiftleft/bctrace/asm/primitive/direct/callsite/CallSitePrimitive.java
@@ -22,10 +22,10 @@
  * CONVEY OR IMPLY ANY RIGHTS TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS
  * CONTENTS, OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT MAY DESCRIBE, IN WHOLE OR IN PART.
  */
-package io.shiftleft.bctrace.asm.helper.direct.callsite;
+package io.shiftleft.bctrace.asm.primitive.direct.callsite;
 
 import io.shiftleft.bctrace.asm.CallbackTransformer;
-import io.shiftleft.bctrace.asm.helper.Helper;
+import io.shiftleft.bctrace.asm.primitive.InstrumentationPrimitive;
 import io.shiftleft.bctrace.asm.util.ASMUtils;
 import io.shiftleft.bctrace.filter.CallSiteFilter;
 import io.shiftleft.bctrace.hook.Hook;
@@ -55,7 +55,7 @@ import org.objectweb.asm.tree.VarInsnNode;
  * is about to be executed.
  *
  * Suppose one listener interested in calls to <tt>System.arrayCopy(Object, int, Object, int,
- * int)</tt> Then this helper turns a method with this call:
+ * int)</tt> Then this primitive turns a method with this call:
  * <br><pre>{@code
  * System.arrayCopy(src, 0, target, 0, length);
  * }
@@ -69,17 +69,19 @@ import org.objectweb.asm.tree.VarInsnNode;
  * }
  * @author Ignacio del Valle Alles idelvall@shiftleft.io
  */
-public class CallSiteHelper extends Helper {
+public class CallSitePrimitive extends InstrumentationPrimitive {
+
 
   /**
    * Iterates over all instructions and for each call site adds corresponding instructions
    *
    * @return true if the method has been transformed. False otherwise
    */
-  public boolean addByteCodeInstructions(ClassNode cn, MethodNode mn,
+  @Override
+  public boolean addByteCodeInstructions(String classResgistryName, ClassNode cn, MethodNode mn,
       ArrayList<Integer> hooksToUse) {
 
-    // Helper local variables
+    // InstrumentationPrimitive local variables
     int callSiteInstanceVarIndex = mn.maxLocals;
     mn.maxLocals = mn.maxLocals + 1;
     int throwableVarIndex = mn.maxLocals;

--- a/core/src/main/java/io/shiftleft/bctrace/asm/primitive/direct/method/DirectMethodReturnPrimitive.java
+++ b/core/src/main/java/io/shiftleft/bctrace/asm/primitive/direct/method/DirectMethodReturnPrimitive.java
@@ -22,10 +22,10 @@
  * CONVEY OR IMPLY ANY RIGHTS TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS
  * CONTENTS, OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT MAY DESCRIBE, IN WHOLE OR IN PART.
  */
-package io.shiftleft.bctrace.asm.helper.direct.method;
+package io.shiftleft.bctrace.asm.primitive.direct.method;
 
 import io.shiftleft.bctrace.asm.CallbackTransformer;
-import io.shiftleft.bctrace.asm.helper.Helper;
+import io.shiftleft.bctrace.asm.primitive.InstrumentationPrimitive;
 import io.shiftleft.bctrace.asm.util.ASMUtils;
 import io.shiftleft.bctrace.hook.Hook;
 import io.shiftleft.bctrace.runtime.listener.direct.DirectListener;
@@ -40,9 +40,10 @@ import org.objectweb.asm.tree.InsnList;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
 
-public class DirectMethodReturnHelper extends Helper {
+public class DirectMethodReturnPrimitive extends InstrumentationPrimitive {
 
-  public boolean addByteCodeInstructions(ClassNode cn, MethodNode mn,
+  @Override
+  public boolean addByteCodeInstructions(String classRegistryName, ClassNode cn, MethodNode mn,
       ArrayList<Integer> hooksToUse) {
 
     ArrayList<Integer> listenersToUse = getListenersOfType(hooksToUse,
@@ -54,8 +55,7 @@ public class DirectMethodReturnHelper extends Helper {
     return true;
   }
 
-  private void addReturnTrace(ClassNode cn, MethodNode mn,
-      ArrayList<Integer> listenersToUse) {
+  private void addReturnTrace(ClassNode cn, MethodNode mn, ArrayList<Integer> listenersToUse) {
 
     InsnList il = mn.instructions;
     Iterator<AbstractInsnNode> it = il.iterator();

--- a/core/src/main/java/io/shiftleft/bctrace/asm/primitive/direct/method/DirectMethodStartPrimitive.java
+++ b/core/src/main/java/io/shiftleft/bctrace/asm/primitive/direct/method/DirectMethodStartPrimitive.java
@@ -22,13 +22,12 @@
  * CONVEY OR IMPLY ANY RIGHTS TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS
  * CONTENTS, OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT MAY DESCRIBE, IN WHOLE OR IN PART.
  */
-package io.shiftleft.bctrace.asm.helper.direct.method;
+package io.shiftleft.bctrace.asm.primitive.direct.method;
 
 import io.shiftleft.bctrace.asm.CallbackTransformer;
-import io.shiftleft.bctrace.asm.helper.Helper;
+import io.shiftleft.bctrace.asm.primitive.InstrumentationPrimitive;
 import io.shiftleft.bctrace.asm.util.ASMUtils;
 import io.shiftleft.bctrace.hook.Hook;
-import io.shiftleft.bctrace.runtime.listener.direct.DirectListener;
 import io.shiftleft.bctrace.runtime.listener.direct.DirectMethodStartListener;
 import java.util.ArrayList;
 import org.objectweb.asm.Opcodes;
@@ -38,9 +37,10 @@ import org.objectweb.asm.tree.InsnList;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
 
-public class DirectMethodStartHelper extends Helper {
+public class DirectMethodStartPrimitive extends InstrumentationPrimitive {
 
-  public boolean addByteCodeInstructions(ClassNode cn, MethodNode mn,
+  @Override
+  public boolean addByteCodeInstructions(String classRegistryName, ClassNode cn, MethodNode mn,
       ArrayList<Integer> hooksToUse) {
 
     ArrayList<Integer> listenersToUse = getListenersOfType(hooksToUse,

--- a/core/src/main/java/io/shiftleft/bctrace/asm/primitive/direct/method/DirectMethodThrowablePrimitive.java
+++ b/core/src/main/java/io/shiftleft/bctrace/asm/primitive/direct/method/DirectMethodThrowablePrimitive.java
@@ -22,15 +22,15 @@
  * CONVEY OR IMPLY ANY RIGHTS TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS
  * CONTENTS, OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT MAY DESCRIBE, IN WHOLE OR IN PART.
  */
-package io.shiftleft.bctrace.asm.helper.generic.method;
+package io.shiftleft.bctrace.asm.primitive.direct.method;
 
 import io.shiftleft.bctrace.Bctrace;
-import io.shiftleft.bctrace.MethodInfo;
-import io.shiftleft.bctrace.MethodRegistry;
-import io.shiftleft.bctrace.asm.helper.Helper;
+import io.shiftleft.bctrace.asm.CallbackTransformer;
+import io.shiftleft.bctrace.asm.primitive.InstrumentationPrimitive;
 import io.shiftleft.bctrace.asm.util.ASMUtils;
 import io.shiftleft.bctrace.logging.Level;
-import io.shiftleft.bctrace.runtime.listener.generic.GenericMethodThrowableListener;
+import io.shiftleft.bctrace.runtime.listener.direct.DirectListener;
+import io.shiftleft.bctrace.runtime.listener.direct.DirectMethodThrowableListener;
 import java.util.ArrayList;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -42,54 +42,19 @@ import org.objectweb.asm.tree.LabelNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.TryCatchBlockNode;
-import org.objectweb.asm.tree.TypeInsnNode;
+import org.objectweb.asm.tree.VarInsnNode;
 
-/**
- * Inserts the bytecode instructions within method node, needed to handle the return listeners
- * registered.
- *
- * This helper turns the method node instructions of a method like this:
- * <br><pre>{@code
- * public Object foo(Object arg){
- *   return void(arg);
- * }
- * }
- * </pre>
- * Into that:
- * <br><pre>{@code
- * public Object foo(Object arg){
- *   try{
- *     Object ret = void(arg);
- *     // Notify listeners that apply to this method
- *     ret = Callback.onFinish(ret, ret, null, clazz, this, 0, arg);
- *     ret = Callback.onFinish(ret, ret, null, clazz, this, 2, arg);
- *     ret = Callback.onFinish(ret, ret, null, clazz, this, 10, arg);
- *     // Return the original value
- *     return ret;
- *   } catch (Throwable th){
- *     th = Callback.onFinish(th, null, th, clazz, this, 0, arg);
- *     th = Callback.onFinish(th, null, th, clazz, this, 2, arg);
- *     th = Callback.onFinish(th, null, th, clazz, this, 10, arg);
- *     throw th;
- *   }
- * }
- * </pre>
- *
- * @author Ignacio del Valle Alles idelvall@shiftleft.io
- */
-public class GenericMethodThrowableHelper extends Helper {
+public class DirectMethodThrowablePrimitive extends InstrumentationPrimitive {
 
-
-  public boolean addByteCodeInstructions(ClassNode cn, MethodNode mn,
+  @Override
+  public boolean addByteCodeInstructions(String classRegistryName, ClassNode cn, MethodNode mn,
       ArrayList<Integer> hooksToUse) {
 
     ArrayList<Integer> listenersToUse = getListenersOfType(hooksToUse,
-        GenericMethodThrowableListener.class);
-
+        DirectMethodThrowableListener.class);
     if (!isInstrumentationNeeded(listenersToUse)) {
       return false;
     }
-
     addTryCatchInstructions(cn, mn, listenersToUse);
     return true;
   }
@@ -105,8 +70,6 @@ public class GenericMethodThrowableHelper extends Helper {
       return false;
     }
 
-    Integer methodId = MethodRegistry.getInstance().registerMethodId(MethodInfo.from(cn.name, mn));
-
     LabelNode endNode = new LabelNode();
     mn.instructions.add(endNode);
 
@@ -118,27 +81,31 @@ public class GenericMethodThrowableHelper extends Helper {
     LabelNode handlerNode = new LabelNode();
     il.add(handlerNode);
 
+    int thVarIndex = mn.maxLocals;
+    mn.maxLocals = mn.maxLocals + 1;
+    il.add(new VarInsnNode(Opcodes.ASTORE, thVarIndex));
+
     for (int i = 0; i < listenersToUse.size(); i++) {
       Integer index = listenersToUse.get(i);
-      GenericMethodThrowableListener listener = (GenericMethodThrowableListener) bctrace
-          .getHooks()[index].getListener();
-      il.add(new InsnNode(Opcodes.DUP)); //throwable
-      il.add(ASMUtils.getPushInstruction(methodId)); // method id
-      il.add(getClassConstantReference(Type.getObjectType(cn.name), cn.version));
-      pushInstance(il, mn); // current instance
+      DirectListener listener = (DirectListener) bctrace.getHooks()[index]
+          .getListener();
       il.add(ASMUtils.getPushInstruction(index)); // hook id
-      if (listener.requiresArguments()) {
-        pushMethodArgsArray(il, mn);
-      } else {
-        il.add(new InsnNode(Opcodes.ACONST_NULL));
-      }
+      il.add(new VarInsnNode(Opcodes.ALOAD, thVarIndex));// original value consumed from the stack
+      il.add(getClassConstantReference(Type.getObjectType(cn.name), cn.version)); // caller class
+      pushInstance(il, mn); // current instance
+      pushMethodArgs(il, mn); // method args
+      il.add(new VarInsnNode(Opcodes.ALOAD, thVarIndex));
+      // Invoke dynamically generated callback method. See CallbackTransformer
       il.add(new MethodInsnNode(Opcodes.INVOKESTATIC,
-          "io/shiftleft/bctrace/runtime/Callback", "onThrow",
-          "(Ljava/lang/Throwable;ILjava/lang/Class;Ljava/lang/Object;I[Ljava/lang/Object;)Ljava/lang/Throwable;",
+          "io/shiftleft/bctrace/runtime/Callback",
+          CallbackTransformer.getDynamicListenerMethodName(listener),
+          CallbackTransformer.getDynamicListenerMutatorMethodDescriptor(listener),
           false));
-
+      // Update return value local variable, so each listener receives the modified value from the ones before
+      // instead of getting all of them the original value
+      il.add(new VarInsnNode(Opcodes.ASTORE, thVarIndex));
     }
-
+    il.add(new VarInsnNode(Opcodes.ALOAD, thVarIndex));
     il.add(new InsnNode(Opcodes.ATHROW));
 
     TryCatchBlockNode blockNode = new TryCatchBlockNode(startNode, endNode, handlerNode, null);

--- a/core/src/main/java/io/shiftleft/bctrace/asm/primitive/generic/method/GenericMethodStartPrimitive.java
+++ b/core/src/main/java/io/shiftleft/bctrace/asm/primitive/generic/method/GenericMethodStartPrimitive.java
@@ -22,13 +22,13 @@
  * CONVEY OR IMPLY ANY RIGHTS TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS
  * CONTENTS, OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT MAY DESCRIBE, IN WHOLE OR IN PART.
  */
-package io.shiftleft.bctrace.asm.helper.generic.method;
+package io.shiftleft.bctrace.asm.primitive.generic.method;
 
 import io.shiftleft.bctrace.MethodInfo;
 import io.shiftleft.bctrace.MethodRegistry;
-import io.shiftleft.bctrace.asm.helper.Helper;
+import io.shiftleft.bctrace.asm.primitive.InstrumentationPrimitive;
 import io.shiftleft.bctrace.asm.util.ASMUtils;
-import io.shiftleft.bctrace.runtime.listener.generic.GenericMethodMutableStartListener;
+import io.shiftleft.bctrace.runtime.listener.generic.GenericMethodStartListener;
 import java.util.ArrayList;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -37,7 +37,6 @@ import org.objectweb.asm.tree.InsnList;
 import org.objectweb.asm.tree.InsnNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
-import org.objectweb.asm.tree.TypeInsnNode;
 
 /**
  * Inserts the bytecode instructions within method node, needed to handle the different start
@@ -45,17 +44,19 @@ import org.objectweb.asm.tree.TypeInsnNode;
  *
  * @author Ignacio del Valle Alles idelvall@shiftleft.io
  */
-public class GenericMethodMutableStartHelper extends Helper {
+public class GenericMethodStartPrimitive extends InstrumentationPrimitive {
 
-  public boolean addByteCodeInstructions(ClassNode cn, MethodNode mn,
+  @Override
+  public boolean addByteCodeInstructions(String classRegistryName, ClassNode cn, MethodNode mn,
       ArrayList<Integer> hooksToUse) {
 
-    return addMutableTraceStart(cn, mn, hooksToUse);
+    return addTraceStart(classRegistryName, cn, mn, hooksToUse);
   }
 
+
   /**
-   * Depending on the {@link GenericMethodMutableStartListener} listeners that apply to this method,
-   * this helper turns the method node instructions of a method like this:
+   * Depending on the {@link GenericMethodStartListener} listeners that apply to this method,  this
+   * primitive turns the method node instructions of a method like this:
    * <br><pre>{@code
    * public Object foo(Object arg1, Object arg2, ..., Object argn){
    *   return void(arg1, arg2, ..., argn);
@@ -66,31 +67,30 @@ public class GenericMethodMutableStartHelper extends Helper {
    * <br><pre>{@code
    * public Object foo(Object args){
    *   Object[] args = new Object[]{arg1, arg2, ..., argn};
+   *   Object ret = void(args);
    *   // Notify listeners that apply to this method (methodId 1550)
-   *   args = Callback.onStart(args, 1550, clazz, this, 0);
-   *   args = Callback.onStart(args, 1550, clazz, this, 2);
-   *   args = Callback.onStart(args, 1550, clazz, this, 10);
+   *   Callback.onStart(args, 1550, clazz, this, 0);
+   *   Callback.onStart(args, 1550, clazz, this, 2);
+   *   Callback.onStart(args, 1550, clazz, this, 10);
    *   return void(arg1, arg2, ..., argn);
    * }
    * }
    * </pre>
    */
-  private boolean addMutableTraceStart(ClassNode cn, MethodNode mn,
+  private boolean addTraceStart(String classRegistryName, ClassNode cn, MethodNode mn,
       ArrayList<Integer> hooksToUse) {
     ArrayList<Integer> listenersToUse = getListenersOfType(hooksToUse,
-        GenericMethodMutableStartListener.class);
+        GenericMethodStartListener.class);
     if (!isInstrumentationNeeded(listenersToUse)) {
       return false;
     }
-    Integer methodId = MethodRegistry.getInstance().registerMethodId(MethodInfo.from(cn.name, mn));
+    Integer methodId = MethodRegistry.getInstance().registerMethodId(MethodInfo.from(classRegistryName, mn));
     InsnList il = new InsnList();
-    Type[] methodArguments = Type.getArgumentTypes(mn.desc);
     boolean someRequiresArguments = false;
     for (int i = 0; i < listenersToUse.size(); i++) {
       Integer index = listenersToUse.get(i);
-      GenericMethodMutableStartListener listener = (GenericMethodMutableStartListener) bctrace
-          .getHooks()[index]
-          .getListener();
+      GenericMethodStartListener listener = (GenericMethodStartListener) bctrace
+          .getHooks()[index].getListener();
       if (listener.requiresArguments()) {
         someRequiresArguments = true;
         break;
@@ -103,50 +103,20 @@ public class GenericMethodMutableStartHelper extends Helper {
     }
     for (int i = 0; i < listenersToUse.size(); i++) {
       Integer index = listenersToUse.get(i);
-      GenericMethodMutableStartListener listener = (GenericMethodMutableStartListener) bctrace
-          .getHooks()[index]
-          .getListener();
+      GenericMethodStartListener listener = (GenericMethodStartListener) bctrace
+          .getHooks()[index].getListener();
+      if (i < listenersToUse.size() - 1) {
+        il.add(new InsnNode(Opcodes.DUP));
+      }
       il.add(ASMUtils.getPushInstruction(methodId));
       il.add(getClassConstantReference(Type.getObjectType(cn.name), cn.version)); // class
       pushInstance(il, mn); // current instance
       il.add(ASMUtils.getPushInstruction(index));
       il.add(new MethodInsnNode(Opcodes.INVOKESTATIC,
-          "io/shiftleft/bctrace/runtime/Callback", "onMutableStart",
-          "([Ljava/lang/Object;ILjava/lang/Class;Ljava/lang/Object;I)[Ljava/lang/Object;", false));
-      overwriteMethodArgsFromArray(il, mn);
+          "io/shiftleft/bctrace/runtime/Callback", "onStart",
+          "([Ljava/lang/Object;ILjava/lang/Class;Ljava/lang/Object;I)V", false));
     }
-    il.add(new InsnNode(Opcodes.POP));
     mn.instructions.insert(il);
     return true;
   }
-
-  /**
-   * Overwrites the argument local variables from the array in top of the operand stack
-   */
-  protected void overwriteMethodArgsFromArray(InsnList il, MethodNode mn) {
-    Type[] methodArguments = Type.getArgumentTypes(mn.desc);
-    if (methodArguments.length > 0) {
-      int index = ASMUtils.isStatic(mn.access) ? 0 : 1;
-      for (int i = 0; i < methodArguments.length; i++) {
-        il.add(new InsnNode(Opcodes.DUP));
-        il.add(ASMUtils.getPushInstruction(i));
-        il.add(new InsnNode(Opcodes.AALOAD));
-        MethodInsnNode wrapperToPrimitiveInst = ASMUtils
-            .getWrapperToPrimitiveInst(methodArguments[i]);
-        String castType = methodArguments[i].getInternalName();
-        String wrapperType = ASMUtils.getWrapper(methodArguments[i]);
-        if (wrapperType != null) {
-          castType = wrapperType;
-        }
-        il.add(new TypeInsnNode(Opcodes.CHECKCAST, castType));
-        if (wrapperToPrimitiveInst != null) {
-          il.add(wrapperToPrimitiveInst);
-        }
-        il.add(ASMUtils.getStoreInst(methodArguments[i], index));
-        index += methodArguments[i].getSize();
-      }
-    }
-  }
 }
-
-

--- a/core/src/main/java/io/shiftleft/bctrace/filter/ClassFilter.java
+++ b/core/src/main/java/io/shiftleft/bctrace/filter/ClassFilter.java
@@ -24,9 +24,8 @@
  */
 package io.shiftleft.bctrace.filter;
 
-import io.shiftleft.bctrace.hierarchy.BctraceClass;
+import io.shiftleft.bctrace.hierarchy.UnloadedClass;
 import java.security.ProtectionDomain;
-import org.objectweb.asm.tree.MethodNode;
 
 /**
  * Determines if a class is instrumented.
@@ -53,7 +52,7 @@ public abstract class ClassFilter {
    * The class bytecode has been parsed at this point, and the class hierarchy is accessible through
    * the BctraceClass API.
    */
-  public boolean acceptClass(BctraceClass clazz, ProtectionDomain protectionDomain,
+  public boolean acceptClass(UnloadedClass clazz, ProtectionDomain protectionDomain,
       ClassLoader cl) {
     return true;
   }

--- a/core/src/main/java/io/shiftleft/bctrace/filter/MethodFilter.java
+++ b/core/src/main/java/io/shiftleft/bctrace/filter/MethodFilter.java
@@ -120,7 +120,7 @@ public abstract class MethodFilter extends ClassFilter {
     }
 
     @Override
-    public boolean acceptClass(BctraceClass clazz, ProtectionDomain protectionDomain,
+    public boolean acceptClass(UnloadedClass clazz, ProtectionDomain protectionDomain,
         ClassLoader cl) {
 
       if (!virtual) {

--- a/core/src/main/java/io/shiftleft/bctrace/hierarchy/BctraceClass.java
+++ b/core/src/main/java/io/shiftleft/bctrace/hierarchy/BctraceClass.java
@@ -208,4 +208,8 @@ public abstract class BctraceClass {
     }
     return false;
   }
+
+  public ClassLoader getClassloader() {
+    return cl;
+  }
 }

--- a/core/src/main/java/io/shiftleft/bctrace/hierarchy/UnloadedClass.java
+++ b/core/src/main/java/io/shiftleft/bctrace/hierarchy/UnloadedClass.java
@@ -36,9 +36,11 @@ import org.objectweb.asm.tree.ClassNode;
 /**
  * @author Ignacio del Valle Alles idelvall@shiftleft.io
  */
-public class UnloadedClass extends BctraceClass {
+public final class UnloadedClass extends BctraceClass {
 
   private final ClassNode cn;
+  private String registryClassName;
+
 
   UnloadedClass(String name, ClassLoader cl, Instrumentation instrumentation)
       throws ClassNotFoundException {
@@ -49,6 +51,14 @@ public class UnloadedClass extends BctraceClass {
   public UnloadedClass(String name, ClassLoader cl, ClassNode cn, Instrumentation instrumentation) {
     super(name, cl, instrumentation);
     this.cn = cn;
+  }
+
+  public void setRegistryClassName(String registryClassName) {
+    this.registryClassName = registryClassName;
+  }
+
+  public String getRegistryClassName() {
+    return registryClassName;
   }
 
   private static ClassNode createClassNode(final URL url) throws ClassNotFoundException {


### PR DESCRIPTION
This PR includes some minor refactors (naming) and a feature needed for https://github.com/ShiftLeftSecurity/product/issues/2502: allowing setting the class name associated to the instrumented methods (different from the actual class instrumented).

This adds a way to solve JSP translation support in the agent but I am not happy with the current `MethodRegistry` design. I will change it to be readonly in the API (agent side) and performing the binding (to the SPR classes) by external (to bctrace) means.